### PR TITLE
chat-spaceのDB設計(README.mdの作成)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+public/uploads/*

--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@
 |nickname|string|null: false|
 
 ### Association
-- has_many :groups, through: :group_users
+- has_many :groups
 - has_many :messages
-- has_many :group_users
+- has_many :photos
 
 ## groupsテーブル
 |column|Type|Options|
 |------|----|-------|
 |name|string|null: false|
+|group_user_id|integer|null: false, foreign_key: true|
 
 ### Association
 - has_many :users, through: :group_users
 - has_many :messages
-- has_many :group_users
 
 ## group_usersテーブル
 |column|Type|Options|
@@ -34,7 +34,7 @@
 ## messagesテーブル
 |column|Type|Options|
 |------|----|-------|
-|text|text||
+|text|string|null: false|
 |photo|string||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
@@ -42,3 +42,12 @@
 ### Association
 - belongs_to :user
 - belongs_to :group
+
+## photosテーブル
+|column|Type|Options|
+|------|----|-------|
+|file|string|null: false|
+|message_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :message

--- a/README.md
+++ b/README.md
@@ -1,24 +1,53 @@
-# README
+# chat-spaceのDB設計
+## usersテーブル
+|column|Type|Options|
+|------|----|-------|
+|email|string|null: false|
+|password|string|null: false|
+|nickname|string|null: false|
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+### Association
+- has_many :groups
+- has_many :messages
+- has_many :photos
 
-Things you may want to cover:
+## groupsテーブル
+|column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|group_user_id|integer|null: false, foreign_key: true|
 
-* Ruby version
+### Association
+- has_many :users, through: :group_users
+- has_many :messages
 
-* System dependencies
+## group_usersテーブル
+|column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
-* Configuration
+### Association
+- belongs_to :user
+- belomgs_to :group
 
-* Database creation
+## messagesテーブル
+|column|Type|Options|
+|------|----|-------|
+|text|string|null: false|
+|photo|string||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
-* Database initialization
+### Association
+- belongs_to :user
+- belongs_to :group
 
-* How to run the test suite
+## photosテーブル
+|column|Type|Options|
+|------|----|-------|
+|file|string|null: false|
+|message_id|integer|null: false, foreign_key: true|
 
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+### Association
+- belongs_to :message

--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@
 |nickname|string|null: false|
 
 ### Association
-- has_many :groups
+- has_many :groups,through: :group_users
 - has_many :messages
-- has_many :photos
+- has_many :group_users
 
 ## groupsテーブル
 |column|Type|Options|
 |------|----|-------|
 |name|string|null: false|
-|group_user_id|integer|null: false, foreign_key: true|
 
 ### Association
 - has_many :users, through: :group_users
 - has_many :messages
+- has_many :group_users
 
 ## group_usersテーブル
 |column|Type|Options|
@@ -34,7 +34,7 @@
 ## messagesテーブル
 |column|Type|Options|
 |------|----|-------|
-|text|string|null: false|
+|text|text||
 |photo|string||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
@@ -42,12 +42,3 @@
 ### Association
 - belongs_to :user
 - belongs_to :group
-
-## photosテーブル
-|column|Type|Options|
-|------|----|-------|
-|file|string|null: false|
-|message_id|integer|null: false, foreign_key: true|
-
-### Association
-- belongs_to :message

--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@
 |nickname|string|null: false|
 
 ### Association
-- has_many :groups
+- has_many :groups, through: :group_users
 - has_many :messages
-- has_many :photos
+- has_many :group_users
 
 ## groupsテーブル
 |column|Type|Options|
 |------|----|-------|
 |name|string|null: false|
-|group_user_id|integer|null: false, foreign_key: true|
 
 ### Association
 - has_many :users, through: :group_users
 - has_many :messages
+- has_many :group_users
 
 ## group_usersテーブル
 |column|Type|Options|
@@ -34,7 +34,7 @@
 ## messagesテーブル
 |column|Type|Options|
 |------|----|-------|
-|text|string|null: false|
+|text|text||
 |photo|string||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
@@ -42,12 +42,3 @@
 ### Association
 - belongs_to :user
 - belongs_to :group
-
-## photosテーブル
-|column|Type|Options|
-|------|----|-------|
-|file|string|null: false|
-|message_id|integer|null: false, foreign_key: true|
-
-### Association
-- belongs_to :message


### PR DESCRIPTION
# What
chat-spaceのDB設計にあたり、README.mdを下記の内容で記述。
usersテーブル、groupsテーブル、messagesテーブル、photosテーブルを作成。
中間テーブルとしてgroup_usersテーブルを作成した。

# Why
ユーザー登録機能より、usersテーブル
グループ登録機能より、groupsテーブル
記事投稿機能より、messagesテーブル
画像投稿機能より、photosテーブル
が必要と考え、それぞれ作成した。
ユーザーとグループは多対多の為、中間テーブルとしてgroup_usersテーブルを作成した。